### PR TITLE
fix(deps): bump form-data to 4.0.6 (CRLF injection, alert #82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "glob": "^11.1.0",
       "jsondiffpatch": "^0.7.2",
       "@eslint/plugin-kit": "^0.3.4",
-      "form-data": "^4.0.4",
+      "form-data": ">=4.0.6 <5",
       "langsmith": "^0.6.0",
       "@langchain/core": "^0.3.80",
       "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   glob: ^11.1.0
   jsondiffpatch: ^0.7.2
   '@eslint/plugin-kit': ^0.3.4
-  form-data: ^4.0.4
+  form-data: '>=4.0.6 <5'
   langsmith: ^0.6.0
   '@langchain/core': ^0.3.80
   zod: ^3.25.76
@@ -1265,8 +1265,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
@@ -1336,6 +1336,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hono@4.12.18:
@@ -2638,7 +2642,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 22.15.14
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@18.19.97':
     dependencies:
@@ -3025,7 +3029,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.25.4:
     optionalDependencies:
@@ -3311,12 +3315,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-node@4.4.1:
@@ -3383,6 +3387,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
Patches `form-data` CRLF injection (unescaped multipart field names/filenames). Tightens the existing override `^4.0.4` → `>=4.0.6 <5`; lockfile moves 4.0.5 → 4.0.6. Resolves Dependabot alert #82.