### PR TITLE
fix(deps): bump vite 6.4.3 + js-yaml 4.2.0 (alerts #83-85)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
-    "vite": "^6.4.2",
+    "vite": "^6.4.3",
     "vitest": "^3.1.3"
   },
   "pnpm": {
@@ -57,7 +57,7 @@
       "qs": "^6.14.2",
       "@modelcontextprotocol/sdk": "^1.26.0",
       "body-parser": "^2.2.1",
-      "js-yaml": "^4.1.1",
+      "js-yaml": ">=4.2.0 <5",
       "glob": "^11.1.0",
       "jsondiffpatch": "^0.7.2",
       "@eslint/plugin-kit": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   qs: ^6.14.2
   '@modelcontextprotocol/sdk': ^1.26.0
   body-parser: ^2.2.1
-  js-yaml: ^4.1.1
+  js-yaml: '>=4.2.0 <5'
   glob: ^11.1.0
   jsondiffpatch: ^0.7.2
   '@eslint/plugin-kit': ^0.3.4
@@ -65,8 +65,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.15.14)(yaml@2.9.0)
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@22.15.14)(yaml@2.9.0)
       vitest:
         specifier: ^3.1.3
         version: 3.1.3(@types/node@22.15.14)(yaml@2.9.0)
@@ -1431,8 +1431,8 @@ packages:
   js-tiktoken@1.0.20:
     resolution: {integrity: sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2068,8 +2068,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2348,7 +2348,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2738,13 +2738,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.4.2(@types/node@22.15.14)(yaml@2.9.0))':
+  '@vitest/mocker@3.1.3(vite@6.4.3(@types/node@22.15.14)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.14)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@22.15.14)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -2842,7 +2842,7 @@ snapshots:
       ajv: 8.20.0
       compute-cosine-similarity: 1.1.0
       js-levenshtein: 1.1.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       linear-sum-assignment: 1.0.7
       mustache: 4.2.0
       openai: 4.47.1
@@ -3469,7 +3469,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4069,7 +4069,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@22.15.14)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@22.15.14)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4084,7 +4084,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(@types/node@22.15.14)(yaml@2.9.0):
+  vite@6.4.3(@types/node@22.15.14)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.4)
@@ -4100,7 +4100,7 @@ snapshots:
   vitest@3.1.3(@types/node@22.15.14)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.4.2(@types/node@22.15.14)(yaml@2.9.0))
+      '@vitest/mocker': 3.1.3(vite@6.4.3(@types/node@22.15.14)(yaml@2.9.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -4117,7 +4117,7 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@22.15.14)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@22.15.14)(yaml@2.9.0)
       vite-node: 3.1.3(@types/node@22.15.14)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
- **vite** 6.4.2 → 6.4.3 — patches `server.fs.deny` bypass on Windows alternate paths (high). In-major patch.
- **js-yaml** 4.1.1 → 4.2.0 — patches quadratic-complexity DoS in merge-key handling. Tightens override.

Resolves Dependabot alerts #83 (js-yaml), #84/#85 (vite).