### PR TITLE
fix(deps): bump js-yaml to >=4.3.0 for merge-key DoS (#87)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "qs": "^6.14.2",
       "@modelcontextprotocol/sdk": "^1.26.0",
       "body-parser": "^2.2.1",
-      "js-yaml": ">=4.2.0 <5",
+      "js-yaml": ">=4.3.0 <5",
       "glob": "^11.1.0",
       "jsondiffpatch": "^0.7.2",
       "@eslint/plugin-kit": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
   qs: ^6.14.2
   '@modelcontextprotocol/sdk': ^1.26.0
   body-parser: ^2.2.1
-  js-yaml: '>=4.2.0 <5'
+  js-yaml: '>=4.3.0 <5'
   glob: ^11.1.0
   jsondiffpatch: ^0.7.2
   '@eslint/plugin-kit': ^0.3.4
@@ -1432,8 +1432,8 @@ packages:
   js-tiktoken@1.0.20:
     resolution: {integrity: sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2350,7 +2350,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2844,7 +2844,7 @@ snapshots:
       ajv: 8.20.0
       compute-cosine-similarity: 1.1.0
       js-levenshtein: 1.1.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       linear-sum-assignment: 1.0.7
       mustache: 4.2.0
       openai: 4.47.1
@@ -3471,7 +3471,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Raise the `js-yaml` override floor from `4.2.0` to `4.3.0` and re-resolve. The 4.2.x line is still in the affected range (`< 4.3.0`) of the quadratic-CPU merge-key-chain advisory (GHSA-h67p-54hq-rp68). Resolves to `4.3.0`, clearing alert #87.