### PR TITLE
fix(deps): resolve Dependabot alerts #89-#93

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   },
   "pnpm": {
     "overrides": {
-      "fast-uri": "^3.1.2",
+      "fast-uri": "^3.1.3",
+      "hono": ">=4.12.27 <5",
+      "@hono/node-server": ">=2.0.5 <3",
       "@fastify/static": "^9.1.1",
       "fastify": "^5.8.5",
       "picomatch@2": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.2
+  fast-uri: ^3.1.3
+  hono: '>=4.12.27 <5'
+  '@hono/node-server': '>=2.0.5 <3'
   '@fastify/static': ^9.1.1
   fastify: ^5.8.5
   picomatch@2: ^2.3.2
@@ -447,11 +449,11 @@ packages:
     peerDependencies:
       '@sinclair/typebox': '>=0.26 <=0.34'
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.27 <5'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1209,8 +1211,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
@@ -1343,8 +1345,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -2371,7 +2373,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
 
   '@fastify/bearer-auth@10.1.1':
     dependencies:
@@ -2434,9 +2436,9 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.33
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.31
 
   '@humanfs/core@0.19.1': {}
 
@@ -2518,7 +2520,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 2.0.11(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2528,7 +2530,7 @@ snapshots:
       eventsource-parser: 3.0.1
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.31
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -2820,7 +2822,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3231,7 +3233,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-ref-resolver: 2.0.1
       rfdc: 1.4.1
 
@@ -3241,7 +3243,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastify-plugin@5.0.1: {}
 
@@ -3396,7 +3398,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.18: {}
+  hono@4.12.31: {}
 
   http-errors@2.0.0:
     dependencies:
@@ -3484,7 +3486,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.0
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Closes Dependabot alerts #89, #90, #91, #92, #93.

## What these are

All five are **lint-time-only transitive deps**, reached through:

```
eslint@9.26.0 -> @modelcontextprotocol/sdk@1.29.0 -> hono / @hono/node-server
```

(`fast-uri` arrives via the fastify/ajv chain.) Nothing here ships in a
published package — every alert is `scope: development`.

## Changes

All via `pnpm.overrides` in the root `package.json`:

| Package | Was | Now | Alerts |
|---|---|---|---|
| `fast-uri` | `^3.1.2` (3.1.2) | `^3.1.3` (3.1.4) | #93 high — host confusion via failed IDN canonicalization |
| `hono` | *(none)* 4.12.18 | `>=4.12.27 <5` (4.12.31) | #90, #91, #92 |
| `@hono/node-server` | *(none)* 1.19.14 | `>=2.0.5 <3` (2.0.11) | #89 — serve-static path traversal |

## The one non-trivial call: `@hono/node-server` 1.x -> 2.x

There is no 1.x patch — the advisory's first patched version is 2.0.5 — so the
override crosses a major boundary past MCP SDK's declared `^1.19.9`.

Verified safe before making the change:

- The SDK imports only `serve` and `getRequestListener` (`server/streamableHttp.js`,
  `examples/server/honoWebStandardStreamableHttp.js`). Both are still exported
  by 2.x.
- It never touches `serveStatic` — the actual vulnerable code — which in 2.x
  isn't even on the root entrypoint (it moved to a `./serve-static` subpath).
- `@modelcontextprotocol/sdk/server/streamableHttp.js` loads cleanly against
  2.0.11.
- 2.x keeps the same `hono: ^4` peer range; `engines.node >= 20` is met.

## Verification

- `pnpm build` passes (all 6 workspace packages).
- `pnpm exec vitest run` — 8 failures, **all pre-existing**: the suite needs a
  live `OPENAI_API_KEY` and network. Same failures on `main`.
- Confirmed resolved versions in `pnpm-lock.yaml`: `fast-uri@3.1.4`,
  `hono@4.12.31`, `@hono/node-server@2.0.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)