### PR TITLE
fix(deps): bump find-my-way to 9.7.0 (GHSA-c96f-x56v-gq3h)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1246,8 +1246,8 @@ packages:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
-  find-my-way@9.3.0:
-    resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -3256,7 +3256,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.1.0
       fast-json-stringify: 6.0.1
-      find-my-way: 9.3.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -3294,7 +3294,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.3.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2


### PR DESCRIPTION
## Summary

Fixes the single open Dependabot security alert on this repo.

| Package | Old | New | Severity | Advisory |
|---|---|---|---|---|
| find-my-way (transitive via fastify) | 9.3.0 | 9.7.0 | HIGH | [GHSA-c96f-x56v-gq3h](https://github.com/advisories/GHSA-c96f-x56v-gq3h) |

## Details

- Lockfile-only change (`pnpm-lock.yaml`), no manifest edits needed: fastify's `find-my-way@^9.0.0` range already permits 9.7.0.
- Applied with `pnpm -r update find-my-way --depth Infinity --lockfile-only` (pnpm 10.33.2, lockfileVersion 9.0 unchanged).
- Verified: the only `find-my-way` entries in `pnpm-lock.yaml` now resolve to 9.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)