### PR TITLE
fix(deps): resolve Dependabot alerts #95-#96 (@fastify/static)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "fast-uri": "^3.1.3",
       "hono": ">=4.12.27 <5",
       "@hono/node-server": ">=2.0.5 <3",
-      "@fastify/static": "^9.1.1",
+      "@fastify/static": "^10.1.2",
       "fastify": "^5.8.5",
       "picomatch@2": "^2.3.2",
       "picomatch@4": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   fast-uri: ^3.1.3
   hono: '>=4.12.27 <5'
   '@hono/node-server': '>=2.0.5 <3'
-  '@fastify/static': ^9.1.1
+  '@fastify/static': ^10.1.2
   fastify: ^5.8.5
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
@@ -435,8 +435,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.1.3':
-    resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@fastify/swagger-ui@5.2.2':
     resolution: {integrity: sha512-jf8xe+D8Xjc8TqrZhtlJImOWihd8iYFu8dhM01mGg+F04CKUM0zGB9aADE9nxzRUszyWp3wn+uWk89nbAoBMCw==}
@@ -968,8 +968,8 @@ packages:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
@@ -1216,6 +1216,9 @@ packages:
 
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
+
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -2402,21 +2405,22 @@ snapshots:
       '@lukeed/ms': 2.0.2
       escape-html: 1.0.3
       fast-decode-uri-component: 1.0.1
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.1.3':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.1.0
       '@fastify/send': 4.1.0
-      content-disposition: 1.1.0
-      fastify-plugin: 5.0.1
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
       fastq: 1.19.1
       glob: 11.1.0
 
   '@fastify/swagger-ui@5.2.2':
     dependencies:
-      '@fastify/static': 9.1.3
+      '@fastify/static': 10.1.2
       fastify-plugin: 5.0.1
       openapi-types: 12.1.3
       rfdc: 1.4.1
@@ -2967,7 +2971,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-disposition@1.1.0: {}
+  content-disposition@2.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -3246,6 +3250,8 @@ snapshots:
   fast-uri@3.1.4: {}
 
   fastify-plugin@5.0.1: {}
+
+  fastify-plugin@6.0.0: {}
 
   fastify@5.8.5:
     dependencies:


### PR DESCRIPTION
## Summary
Bumps the `@fastify/static` pnpm override from `^9.1.1` to `^10.1.2`, clearing both open Dependabot alerts:

- **#96 (high):** route guard bypass via path traversal — GHSA-83w8-p2f5-377r, patched in 10.1.1
- **#95 (medium):** authorization bypass via non-canonical URL paths — GHSA-8pvw-jcv7-9cmj, patched in 10.1.2

`@fastify/static` is a transitive dependency via `@fastify/swagger-ui` in `packages/tau-bench`. This follows the same override approach as the previous alert fixes (#8). Note swagger-ui declares `@fastify/static: ^8.0.0` — it was already force-overridden to 9.x, so 10.x continues the existing off-range pattern; fastify stays at 5.8.5.

## Validation
- `pnpm install` regenerates the lockfile with `@fastify/static@10.1.2` only (no 9.x remains)
- `pnpm -r build` passes for all 6 workspace packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)