### PR TITLE
bump fast-uri and ip-address past the new SSRF advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "pnpm": {
     "overrides": {
-      "fast-uri": "^3.1.3",
+      "fast-uri": "^3.1.5",
+      "ip-address": "^10.3.1",
       "hono": ">=4.12.27 <5",
       "@hono/node-server": ">=2.0.5 <3",
       "@fastify/static": "^10.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.3
+  fast-uri: ^3.1.5
+  ip-address: ^10.3.1
   hono: '>=4.12.27 <5'
   '@hono/node-server': '>=2.0.5 <3'
   '@fastify/static': ^10.1.2
@@ -1212,8 +1213,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
@@ -1391,8 +1392,8 @@ packages:
     resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
     engines: {node: '>= 0.10'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2382,7 +2383,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/bearer-auth@10.1.1':
     dependencies:
@@ -2832,7 +2833,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3187,7 +3188,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -3243,7 +3244,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 2.0.1
       rfdc: 1.4.1
 
@@ -3253,7 +3254,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastify-plugin@5.0.1: {}
 
@@ -3453,7 +3454,7 @@ snapshots:
 
   install@0.13.0: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -3498,7 +3499,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.0
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Clears the 4 open Dependabot alerts on this repo. Both are dev-scope transitives; patch bumps within their existing majors.

- `fast-uri` → `^3.1.5` — host confusion via a backslash authority introducer (GHSA-7p8r-x3mc-p8w7). A `\` after the scheme is parsed as an authority delimiter, so `https:\\evil.com` resolves to a different host than the browser parse.
- `ip-address` → `^10.3.1` *(new override)* — three SSRF / trust-boundary bypasses cleared by 10.3.1: IPv4-mapped and NAT64 misclassification (GHSA-22jq-vg5j-6vgg), a CIDR suffix suppressing special-use classification (GHSA-4xrf-jv44-h6hh), and Address4 reading leading-zero octets as decimal where resolvers read them as octal (GHSA-mwp4-54f8-5fhr).