### PR TITLE
Bump hono override to >=4.12.34 to fix security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "overrides": {
       "fast-uri": "^3.1.5",
       "ip-address": "^10.3.1",
-      "hono": ">=4.12.27 <5",
+      "hono": ">=4.12.34 <5",
       "@hono/node-server": ">=2.0.5 <3",
       "@fastify/static": "^10.1.2",
       "fastify": "^5.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
-  hono: '>=4.12.27 <5'
+  hono: '>=4.12.34 <5'
   '@hono/node-server': '>=2.0.5 <3'
   '@fastify/static': ^10.1.2
   fastify: ^5.8.5
@@ -455,7 +455,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.27 <5'
+      hono: '>=4.12.34 <5'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1350,8 +1350,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -2447,9 +2447,9 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.33
 
-  '@hono/node-server@2.0.11(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.13.1)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.13.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -2531,7 +2531,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.13.1)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2541,7 +2541,7 @@ snapshots:
       eventsource-parser: 3.0.1
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.13.1
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -3411,7 +3411,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.31: {}
+  hono@4.13.1: {}
 
   http-errors@2.0.0:
     dependencies:


### PR DESCRIPTION
Fixes three open Dependabot alerts for `hono`, all patched in 4.12.34:

- **#107 (moderate)** — Algorithmic Complexity DoS in Language Middleware
- **#109 (moderate)** — `memo()` retains SSR output across requests, leading to cross-user data disclosure
- **#108 (low)** — Proxy Helper does not remove response headers listed in the `Connection` header

## Changes
- Raised the pnpm override floor from `hono: ">=4.12.27 <5"` to `">=4.12.34 <5"` so the vulnerable range can't resolve again
- Refreshed `pnpm-lock.yaml` — hono now resolves to **4.13.1** (vite also moved 6.4.2 → 6.4.3 within its existing range)

## Verification
- `pnpm build` passes across all workspace packages
- Test suite not run locally (requires `OPENAI_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)