### PR TITLE
security(deps): patch jsondiffpatch prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "js-yaml": ">=4.3.1 <5",
       "nanoid@3": ">=3.3.17 <4",
       "glob": "^11.1.0",
-      "jsondiffpatch": "^0.7.2",
+      "jsondiffpatch": "^0.7.6",
       "@eslint/plugin-kit": "^0.3.4",
       "form-data": ">=4.0.6 <5",
       "langsmith": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   js-yaml: '>=4.3.1 <5'
   nanoid@3: '>=3.3.17 <4'
   glob: ^11.1.0
-  jsondiffpatch: ^0.7.2
+  jsondiffpatch: ^0.7.6
   '@eslint/plugin-kit': ^0.3.4
   form-data: '>=4.0.6 <5'
   langsmith: ^0.6.0
@@ -1469,8 +1469,8 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jsondiffpatch@0.7.3:
-    resolution: {integrity: sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==}
+  jsondiffpatch@0.7.6:
+    resolution: {integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -2810,7 +2810,7 @@ snapshots:
       '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.76)
       '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.7.3
+      jsondiffpatch: 0.7.6
       zod: 3.25.76
     optionalDependencies:
       react: 19.1.0
@@ -3510,7 +3510,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jsondiffpatch@0.7.3:
+  jsondiffpatch@0.7.6:
     dependencies:
       '@dmsnell/diff-match-patch': 1.1.0
 


### PR DESCRIPTION
Require jsondiffpatch 0.7.6 and refresh the lockfile so the transitive runtime dependency includes the upstream prototype-pollution guards.

Resolves Dependabot alert #114.